### PR TITLE
Fixed incompatible desktop entries

### DIFF
--- a/savagewheels.desktop
+++ b/savagewheels.desktop
@@ -2,9 +2,9 @@
 Encoding=UTF-8
 Name=SavageWheels
 GenericName=Action/Arcade Game
-Version=1.6
+Version=1.0
 Type=Application
-Categories=Game;ActionGame;Racing;
+Categories=Game;ActionGame;
 Keywords=Game;Arcade;2D;Cars;Racing
 Comment=2D car crashing game similar to the old classic Destruction Derby
 TryExec=savagewheels


### PR DESCRIPTION
Version is the version of https://freedesktop.org/wiki/Standards/menu-spec/ not the game and `Racing` is not an approved category. Also, on Unix everything ends with a newline.